### PR TITLE
Database synchronisation bug

### DIFF
--- a/Chapter09/notes/models/notes-sequelize.mjs
+++ b/Chapter09/notes/models/notes-sequelize.mjs
@@ -84,8 +84,7 @@ export async function read(key) {
 export async function destroy(key) { 
     try {
         const SQNote = await connectDB();
-        const note = await SQNote.find({ where: { notekey: key } }) 
-        note.destroy();
+        SQNote.destroy({ where: { notekey: key } });
     } catch (e) {
         error(`notes DESTROY ERROR ${e.stack}`);
         throw e;


### PR DESCRIPTION
I have found that if I destroy the note using the prescribed method, the database becomes temporarily unsynchronised and the next keylist call triggered by the 'notedestroy' event still finds the supposedly destroyed note. This then causes an error to be thrown when a read is attempted with the key. The problem is fixed by calling SQNote.destroy({ where: { notekey: key } }); instead.