### PR TITLE
Problem reading Note class in client side javascript on firefox

### DIFF
--- a/Chapter09/notes/models/notes.mjs
+++ b/Chapter09/notes/models/notes.mjs
@@ -23,7 +23,7 @@ export async function create(key, title, body) {
 export async function update(key, title, body) {
     const note = await (await model()).update(key, title, body);
     debug(`note updated ${util.inspect(note)}`);
-    _events.noteUpdate(note);
+    _events.noteUpdate({ key: note.key, title: note.title, body: note.body });
     return note;
 }
 


### PR DESCRIPTION
I found that my firefox browser wasn't able to extract information from the Note class in noteview.hbs and so I had to extract the required values on the server and send them as a simple object.