### PR TITLE
Added id tag to navbar title span

### DIFF
--- a/Chapter09/notes/partials/header.hbs
+++ b/Chapter09/notes/partials/header.hbs
@@ -24,7 +24,7 @@
     </button>
     {{#if user}}
         <div class="collapse navbar-collapse" id="navbarSupportedContent">
-            <span class="navbar-text text-dark col">{{ title }}</span>
+            <span id="navbartitle" class="navbar-text text-dark col">{{ title }}</span>
             <a class="nav-item nav-link btn btn-dark col-auto" href="/users/logout">
             Log Out <span class="badge badge-light">{{ user.username }}</span></a>
             <a class="nav-item nav-link btn btn-dark col-auto" href='/notes/add'>ADD Note</a>


### PR DESCRIPTION
Without an id tag, you can't update this title using jQuery when you edit a note in another window.